### PR TITLE
Fix script so fonts get copied correctly

### DIFF
--- a/Ubuntu/setup.sh
+++ b/Ubuntu/setup.sh
@@ -108,12 +108,12 @@ sudo apt remove --purge gnome-calculator -y
 
 # Move fonts
 mkdir /usr/share/fonts
-cp -r /home/Linux-Setup/'Google Sans Text Regular.ttf' /usr/share/fonts
-cp -r /home/Linux-Setup/'Google Sans Text Medium.ttf' /usr/share/fonts
-cp -r /home/Linux-Setup/'Google Sans Text Medium Italic.ttf' /usr/share/fonts
-cp -r /home/Linux-Setup/'Google Sans Text Italic.ttf' /usr/share/fonts
-cp -r /home/Linux-Setup/'Google Sans Text Bold.ttf' /usr/share/fonts
-cp -r /home/Linux-Setup/'Google Sans Text Bold Italic.ttf' /usr/share/fonts
+cp -r ./"Google Sans*" /usr/share/fonts
+cp -r ./'Google Sans Text Medium.ttf' /usr/share/fonts
+cp -r ./'Google Sans Text Medium Italic.ttf' /usr/share/fonts
+cp -r ./'Google Sans Text Italic.ttf' /usr/share/fonts
+cp -r ./'Google Sans Text Bold.ttf' /usr/share/fonts
+cp -r ./'Google Sans Text Bold Italic.ttf' /usr/share/fonts
 
 
 # Theming


### PR DESCRIPTION
The repo will almost never be cloned where it is in the font path so instead use the directory the script is run from. Hopefully this syntax works.